### PR TITLE
Fix Markdown Syntax in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Phonological Edit Distance
 This uses the mighty power of [Phonological Corpus Tools](http://phonologicalcorpustools.github.io/CorpusTools/) to calculate the average phonological edit distance of all items in a set. This can be used as a proxy measure of phonological dissimilarity.
 
-###dependencies:
+### Dependencies:
 To run this you must have:  
 * [Python 3](https://www.python.org/download/releases/3.0/)  
 * [Phonological Corpus Tools](http://phonologicalcorpustools.github.io/CorpusTools/)  
@@ -9,10 +9,10 @@ To run this you must have:
     
 ------------------------------------------------------------
 
-###About:  
+### About:  
 The (Levenshtein) edit distance is the number of operations (i.e. add, delete, replace) needed to change one string to another. For example 'bat'->'pat' has an edit distance of 1. But some changes may more phonologically different than others. For example, 'bat'->'rat' differs in more phonological features than 'bat'->'pat'. The phonological edit distance takes the levenshtein edit distance and weights it based off the difference in phonological features. More info can be found [here](http://corpustools.readthedocs.io/en/latest/string_similarity.html#phonological-edit-distance)
 
-###How to use:  
+### How to use:  
 
 Right now there's no pretty input or output methods because I'm lazy, but if you feel like adding them in let me know. With that out of the way...  
 `phonoEditDistanceWITHINsubjects.py` compares a set of words to itself, and `phonoEditDistanceBETWEENsubjects.py` compares a set of words to another set of words.


### PR DESCRIPTION
Fixed some subheaders that were not rendering correctly because of missing spaces.